### PR TITLE
fix: CommandPhaseSteps loop bug

### DIFF
--- a/client/src/components/CommandPhaseSteps.tsx
+++ b/client/src/components/CommandPhaseSteps.tsx
@@ -122,19 +122,16 @@ export default function CommandPhaseSteps({
   const isLastStep = currentStep === COMMAND_PHASE_STEPS.length - 1;
 
   /**
-   * Safety check: if step is undefined and we're beyond the last step, close the panel
+   * Safety check: if step is undefined, close the panel
    * This prevents infinite loops when completing the last substep
    * 
    * When currentStep >= COMMAND_PHASE_STEPS.length, the phase should be complete
-   * and the component should close naturally instead of resetting to step 0
+   * and the component should close naturally instead of attempting state updates during render
+   * 
+   * Since currentStep is controlled only by internal functions that maintain valid values (0 to 2),
+   * this condition should rarely occur, but provides a safety net for edge cases
    */
   if (!step) {
-    // If we're past the last step, the phase should be complete - just close the panel
-    if (currentStep >= COMMAND_PHASE_STEPS.length) {
-      return null;
-    }
-    // Otherwise reset to first step
-    setCurrentStep(0);
     return null;
   }
 


### PR DESCRIPTION
## Descrição

Corrige bug crítico onde completar o último substep da Fase de Comando causava loop infinito voltando ao primeiro passo ao invés de avançar para a próxima fase.

## Mudanças

- Atualizada validação de segurança em CommandPhaseSteps.tsx
- Quando `currentStep >= COMMAND_PHASE_STEPS.length`, retorna `null` ao invés de resetar para 0
- Permite que o componente feche naturalmente após completar a fase

## Como testar

1. Abrir Battle Tracker
2. Clicar em "Mostrar Passos Detalhados da Fase de Comando"
3. Avançar pelos 3 passos até o último
4. Clicar em "Concluir Fase de Comando"
5. Verificar que o painel fecha e a fase é marcada como completa (não volta para Passo 1)

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lançamento

* **New Features**
  * Componentes de fluxo de comando agora aceitam novos parâmetros públicos (identificador de batalha, conclusão, abrir reabastecimento, contagem de jogadores e modo solo) para maior flexibilidade na integração.

* **Bug Fixes**
  * Proteção adicionada contra renderizações inválidas quando a etapa atual não está definida, evitando erros durante transições.

* **Documentation**
  * Exemplos e documentação ampliados com notas de segurança e uso.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->