### PR TITLE
fix: UI layout - Misery Cards and Secondary Missions panels no longer overlap

### DIFF
--- a/client/src/pages/BattleTracker.tsx
+++ b/client/src/pages/BattleTracker.tsx
@@ -788,53 +788,53 @@ function BattleTrackerInner() {
                 status: u.status,
               }))}
             />
-            
-            {/* Misery Cards Panel */}
-            <div className="relative z-20">
-            <MiseryCardsPanel
-              activeCardIds={activeMiseryCardIds}
-              battleRound={battle?.battleRound || 1}
-              onDrawCards={(cards) => {
-                setActiveMiseryCardIds(prev => [...prev, ...cards.map(c => c.id)]);
-                toast.info(`${cards.length} Carta(s) de Miséria comprada(s)!`);
-              }}
-              onDismissCard={(cardId) => {
-                setActiveMiseryCardIds(prev => prev.filter(id => id !== cardId));
-                toast.success('Carta de Miséria removida!');
-              }}
-            />
-            </div>
-            
-            {/* Secondary Missions Panel */}
-            <div className="relative z-20">
-            <SecondaryMissionsPanel
-              activeMissions={activeSecondaryMissions}
-              battleRound={battle?.battleRound || 1}
-              onDrawMissions={(missions) => {
-                setActiveSecondaryMissions(prev => [
-                  ...prev,
-                  ...missions.map(m => ({ missionId: m.id, status: 'active' as const }))
-                ]);
-                toast.info(`${missions.length} Missão(ões) Secundária(s) comprada(s)!`);
-              }}
-              onCompleteMission={(missionId) => {
-                setActiveSecondaryMissions(prev =>
-                  prev.map(m => m.missionId === missionId ? { ...m, status: 'completed' as const } : m)
-                );
-                toast.success('Missão Secundária concluída!');
-              }}
-              onFailMission={(missionId) => {
-                setActiveSecondaryMissions(prev =>
-                  prev.map(m => m.missionId === missionId ? { ...m, status: 'failed' as const } : m)
-                );
-                toast.error('Missão Secundária falhou!');
-              }}
-            />
-            </div>
           </div>
+        </div>
+        
+        {/* Misery Cards and Secondary Missions - Full width row below main grid */}
+        <div className="grid gap-6 lg:grid-cols-2">
+          {/* Misery Cards Panel */}
+          <MiseryCardsPanel
+            activeCardIds={activeMiseryCardIds}
+            battleRound={battle?.battleRound || 1}
+            onDrawCards={(cards) => {
+              setActiveMiseryCardIds(prev => [...prev, ...cards.map(c => c.id)]);
+              toast.info(`${cards.length} Carta(s) de Miséria comprada(s)!`);
+            }}
+            onDismissCard={(cardId) => {
+              setActiveMiseryCardIds(prev => prev.filter(id => id !== cardId));
+              toast.success('Carta de Miséria removida!');
+            }}
+          />
+          
+          {/* Secondary Missions Panel */}
+          <SecondaryMissionsPanel
+            activeMissions={activeSecondaryMissions}
+            battleRound={battle?.battleRound || 1}
+            onDrawMissions={(missions) => {
+              setActiveSecondaryMissions(prev => [
+                ...prev,
+                ...missions.map(m => ({ missionId: m.id, status: 'active' as const }))
+              ]);
+              toast.info(`${missions.length} Missão(ões) Secundária(s) comprada(s)!`);
+            }}
+            onCompleteMission={(missionId) => {
+              setActiveSecondaryMissions(prev =>
+                prev.map(m => m.missionId === missionId ? { ...m, status: 'completed' as const } : m)
+              );
+              toast.success('Missão Secundária concluída!');
+            }}
+            onFailMission={(missionId) => {
+              setActiveSecondaryMissions(prev =>
+                prev.map(m => m.missionId === missionId ? { ...m, status: 'failed' as const } : m)
+              );
+              toast.error('Missão Secundária falhou!');
+            }}
+          />
+        </div>
 
-          {/* Battle Info & Log - moved to bottom or sidebar */}
-          <div className="lg:col-span-5 space-y-6">
+        {/* Battle Info & Log - Full width row */}
+        <div className="grid gap-6 lg:grid-cols-2">
             {/* Battle Info */}
             {battle && (
               <Card>
@@ -893,17 +893,17 @@ function BattleTrackerInner() {
               </CardContent>
             </Card>
 
-            {/* End Battle Button */}
-            <Button
-              variant="destructive"
-              size="lg"
-              className="w-full"
-              onClick={() => setShowSummary(true)}
-            >
-              Finalizar Batalha
-            </Button>
-          </div>
         </div>
+        
+        {/* End Battle Button */}
+        <Button
+          variant="destructive"
+          size="lg"
+          className="w-full"
+          onClick={() => setShowSummary(true)}
+        >
+          Finalizar Batalha
+        </Button>
       </div>
 
       {/* Battle Summary Modal */}

--- a/todo.md
+++ b/todo.md
@@ -923,3 +923,9 @@
 - [x] Atualizado `handlePhaseChange` para chamar `setLocalCurrentTurn(playerTurn)` (linha 419)
 - [x] Turno agora muda corretamente: Horda (5 fases) → Jogador (5 fases) → Round 2
 - [x] Testado e verificado funcionando corretamente
+
+
+### Bug 5: Painéis de Misery Cards e Secondary Missions sobrepostos a outros componentes
+- [x] Corrigir posicionamento dos painéis para não sobrepor Informações da Batalha, Histórico de Fases e botão Finalizar
+- [x] Ajustar layout para que os painéis fiquem em uma área dedicada sem overlap
+- [x] Reorganizado layout: Misery Cards e Secondary Missions agora em uma linha separada abaixo do grid principal


### PR DESCRIPTION
## Resumo das Mudanças

Corrigido o problema de sobreposição onde os painéis de **Cartas de Miséria** e **Missões Secundárias** estavam aparecendo em cima de outros componentes (Informações da Batalha, Histórico de Fases e botão Finalizar Batalha).

### Problema
Os painéis de Misery Cards e Secondary Missions estavam posicionados com `position: relative` e `z-index: 20` dentro de uma coluna de 2 spans, enquanto os componentes de Battle Info estavam em uma linha de 5 spans abaixo. Isso causava sobreposição visual.

### Solução
- Reorganizado o layout do `BattleTracker.tsx`
- Movidos os painéis de Misery Cards e Secondary Missions para uma linha dedicada de largura total abaixo do grid principal
- Battle Info e Phase Log agora em sua própria linha com layout de 2 colunas
- Botão Finalizar Batalha movido para sua própria seção no final
- Removidos hacks de z-index desnecessários

### Como Testar
1. Abrir qualquer batalha no Battle Tracker
2. Rolar para baixo na página
3. Verificar que os painéis de Cartas de Miséria e Missões Secundárias estão em uma linha separada
4. Verificar que não há sobreposição com Informações da Batalha ou Histórico de Fases

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Correções de Bugs**
  * Corrigida sobreposição de painéis na página de rastreamento de batalhas. Painéis de Cartões de Sofrimento e Missões Secundárias agora aparecem em área dedicada, sem conflitar com informações de batalha, histórico de fases e botão finalizar batalha.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->