### PR TITLE
fix: Horde Units panel no longer overlaps Secondary Missions

### DIFF
--- a/client/src/pages/BattleTracker.tsx
+++ b/client/src/pages/BattleTracker.tsx
@@ -773,25 +773,25 @@ function BattleTrackerInner() {
               units={unitStatuses}
               onMarkDestroyed={handleMarkDestroyed}
             />
-            
-            {/* Horde Units Panel */}
-            <HordeUnitsPanel
-              units={hordeUnits}
-              faction={campaign?.hordeFaction || "Horda"}
-              numberOfZones={numberOfZones}
-              onDestroyUnit={handleDestroyHordeUnit}
-              playerUnits={unitStatuses.map(u => ({
-                id: u.id,
-                name: u.name,
-                crusadeName: u.crusadeName,
-                playerName: u.playerName,
-                status: u.status,
-              }))}
-            />
           </div>
         </div>
         
-        {/* Misery Cards and Secondary Missions - Full width row below main grid */}
+        {/* Horde Units Panel - Full width row */}
+        <HordeUnitsPanel
+          units={hordeUnits}
+          faction={campaign?.hordeFaction || "Horda"}
+          numberOfZones={numberOfZones}
+          onDestroyUnit={handleDestroyHordeUnit}
+          playerUnits={unitStatuses.map(u => ({
+            id: u.id,
+            name: u.name,
+            crusadeName: u.crusadeName,
+            playerName: u.playerName,
+            status: u.status,
+          }))}
+        />
+        
+        {/* Misery Cards and Secondary Missions - Full width row */}
         <div className="grid gap-6 lg:grid-cols-2">
           {/* Misery Cards Panel */}
           <MiseryCardsPanel

--- a/todo.md
+++ b/todo.md
@@ -929,3 +929,9 @@
 - [x] Corrigir posicionamento dos painéis para não sobrepor Informações da Batalha, Histórico de Fases e botão Finalizar
 - [x] Ajustar layout para que os painéis fiquem em uma área dedicada sem overlap
 - [x] Reorganizado layout: Misery Cards e Secondary Missions agora em uma linha separada abaixo do grid principal
+
+
+### Bug 6: Painel de Unidades da Horda sobreposto ao painel de Missões Secundárias
+- [x] Corrigir posicionamento do painel de Unidades da Horda
+- [x] Reorganizar layout para que todos os painéis fiquem em posições corretas sem sobreposição
+- [x] Movido Horde Units Panel para uma linha dedicada de largura total abaixo do grid principal


### PR DESCRIPTION
## Resumo das Mudanças

Corrigido o problema de sobreposição onde o painel de **Unidades da Horda** estava aparecendo em cima do painel de **Missões Secundárias**.

### Problema
O painel de Unidades da Horda estava dentro da mesma coluna que o Unit Tracker, mas visualmente aparecia sobreposto ao painel de Missões Secundárias que estava em uma linha abaixo.

### Solução
- Movido o painel de Unidades da Horda para uma linha dedicada de largura total
- Layout agora tem separação clara:
  1. Phase Tracker + Unit Tracker (grid de 5 colunas)
  2. Horde Units Panel (largura total)
  3. Misery Cards + Secondary Missions (grid de 2 colunas)
  4. Battle Info + Phase Log (grid de 2 colunas)
  5. Botão Finalizar Batalha (largura total)

### Como Testar
1. Abrir qualquer batalha no Battle Tracker
2. Rolar para baixo na página
3. Verificar que o painel de Unidades da Horda está em uma linha separada
4. Verificar que não há sobreposição com Missões Secundárias

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Correções de Bugs
* Corrigido o posicionamento do painel de Unidades da Horda que estava sobrepondo o painel de Missões Secundárias. O painel agora ocupa uma linha dedicada em largura completa, eliminando o conflito visual.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->