### PR TITLE
fix: Exclude newly revealed missions from resolution modal

### DIFF
--- a/client/src/pages/BattleTracker.tsx
+++ b/client/src/pages/BattleTracker.tsx
@@ -73,6 +73,7 @@ function BattleTrackerInner() {
   // Secondary Mission Resolution state
   const [showMissionResolutionModal, setShowMissionResolutionModal] = useState(false);
   const [missionResolutionTiming, setMissionResolutionTiming] = useState<'end_of_turn' | 'end_of_round'>('end_of_round');
+  const [missionResolutionRound, setMissionResolutionRound] = useState<number>(1);
   
   // Horde spawn state
   const [showSpawnModal, setShowSpawnModal] = useState(false);
@@ -482,6 +483,7 @@ function BattleTrackerInner() {
         const hasResolvableMissions = activeSecondaryMissions.some(m => m.status === 'active' && m.revealedRound < round);
         if (hasResolvableMissions) {
           setMissionResolutionTiming('end_of_round');
+          setMissionResolutionRound(round);
           setTimeout(() => setShowMissionResolutionModal(true), 600);
         }
       }
@@ -496,6 +498,7 @@ function BattleTrackerInner() {
       const hasResolvableMissions = activeSecondaryMissions.some(m => m.status === 'active' && m.revealedRound < round);
       if (hasResolvableMissions) {
         setMissionResolutionTiming('end_of_turn');
+        setMissionResolutionRound(round);
         setTimeout(() => setShowMissionResolutionModal(true), 300);
       }
     }
@@ -1173,7 +1176,7 @@ function BattleTrackerInner() {
         isOpen={showMissionResolutionModal}
         onClose={() => setShowMissionResolutionModal(false)}
         activeMissions={activeSecondaryMissions
-          .filter(m => m.status === 'active' && m.revealedRound < (battle?.battleRound || 1))
+          .filter(m => m.status === 'active' && m.revealedRound < missionResolutionRound)
           .map(m => getSecondaryMissionById(m.missionId)!)
           .filter(Boolean)}
         timing={missionResolutionTiming}


### PR DESCRIPTION
## Problema

O modal de resolução de missões secundárias estava mostrando missões que acabaram de ser reveladas no round atual, antes dos jogadores terem chance de completá-las. Por exemplo, se a missão #4 (Estabelecer Comunicações Orbitais) fosse revelada no início do Round 2, ela já aparecia no modal de resolução do final do turno do Round 2.

## Solução

Adicionado um campo `revealedRound` ao estado `activeSecondaryMissions` para rastrear em qual round cada missão foi revelada. O modal de resolução agora filtra apenas missões onde `revealedRound < currentRound`.

## Mudanças

- Adicionado campo `revealedRound` ao tipo de estado `activeSecondaryMissions`
- Atualizado todos os locais onde missões são adicionadas (StartOfRoundModal, SecondaryMissionsPanel) para incluir `revealedRound`
- Atualizado triggers de resolução end_of_round e end_of_turn para verificar apenas missões de rounds anteriores
- Atualizado prop `activeMissions` do SecondaryMissionResolutionModal para filtrar por `revealedRound < currentRound`

## Como testar

1. Iniciar uma batalha e avançar até o Round 2
2. No início do Round 2, uma nova missão secundária será revelada
3. Ao final do turno do jogador no Round 2, o modal de resolução deve mostrar apenas missões do Round 1 (não a recém-revelada)
4. No Round 3, a missão do Round 2 deve aparecer para resolução

```bash
pnpm test
```

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Missões secundárias agora registram a rodada em que são reveladas e só podem ser resolvidas em rodadas posteriores, melhorando a ordem e previsibilidade da resolução.
* **Correções**
  * Fluxos de início de rodada e de revelação garantem que novas missões tenham a informação de tempo registrada, evitando resoluções prematuras.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->