### PR TITLE
feat: separate build outputs into dist/client and dist/server (Issue #36)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,9 +16,9 @@ This document describes the current architecture of the application based exclus
 | **Backend** | Express 4, tRPC 11, TypeScript | RPC-first API under `/api/trpc` |
 | **Database** | MySQL / TiDB | Managed via Drizzle ORM; connection string in `DATABASE_URL` |
 | **Auth** | Manus OAuth | Session cookie; callback at `/api/oauth/callback` |
-| **Build** | Vite (frontend), esbuild (server bundle) | Single `pnpm build` produces both client and server artifacts |
+| **Build** | Vite (frontend), esbuild (server bundle) | `pnpm build` produces `dist/client/` (static assets) and `dist/server/index.js` (server bundle) |
 | **Package Manager** | pnpm 10.4.1 | Lockfile: `pnpm-lock.yaml` |
-| **Runtime** | Node.js 20+ | CI uses Node 20; local dev uses `tsx watch` |
+| **Runtime** | Node.js >= 20.11 | `import.meta.dirname` requires Node 20.11+; CI uses Node 20; local dev uses `tsx watch` |
 | **Testing** | Vitest | Server-side tests only (`server/**/*.test.ts`) |
 | **Serialisation** | Superjson | Drizzle rows (including `Date`) pass through tRPC without manual conversion |
 
@@ -71,8 +71,8 @@ The following commands are available in `package.json`:
 |---|---|
 | `pnpm install` | Install all dependencies |
 | `pnpm dev` | Start the dev server (`tsx watch server/_core/index.ts`) with hot-reload |
-| `pnpm build` | Production build: Vite for client, esbuild for server → `dist/` |
-| `pnpm start` | Run the production build (`node dist/index.js`) |
+| `pnpm build` | Production build: Vite → `dist/client/`, esbuild → `dist/server/index.js` |
+| `pnpm start` | Run the production build (`node dist/server/index.js`) |
 | `pnpm check` | TypeScript type-check (`tsc --noEmit`) |
 | `pnpm format` | Format code with Prettier |
 | `pnpm test` | Run Vitest test suite |

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch server/_core/index.ts",
-    "build": "vite build && esbuild server/_core/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "NODE_ENV=production node dist/index.js",
+    "build": "vite build && esbuild server/_core/index.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/server/index.js",
+    "start": "NODE_ENV=production node dist/server/index.js",
     "check": "tsc --noEmit",
     "format": "prettier --write .",
     "test": "vitest run",

--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -50,8 +50,8 @@ export async function setupVite(app: Express, server: Server) {
 export function serveStatic(app: Express) {
   const distPath =
     process.env.NODE_ENV === "development"
-      ? path.resolve(import.meta.dirname, "../..", "dist", "public")
-      : path.resolve(import.meta.dirname, "public");
+      ? path.resolve(import.meta.dirname, "../..", "dist", "client")
+      : path.resolve(import.meta.dirname, "..", "client");
   if (!fs.existsSync(distPath)) {
     console.error(
       `Could not find the build directory: ${distPath}, make sure to build the client first`

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   root: path.resolve(import.meta.dirname, "client"),
   publicDir: path.resolve(import.meta.dirname, "client", "public"),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
+    outDir: path.resolve(import.meta.dirname, "dist/client"),
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
## Summary

Separates build outputs into `dist/client/` (Vite frontend) and `dist/server/index.js` (esbuild backend), making the project portable for deployment outside Manus.

## Why (Business Context)

Resolves #36. Part of the `exit-manus` epic (#34). The previous build structure placed everything under `dist/` with the client in `dist/public/` and the server at `dist/index.js`. This made it harder to deploy the frontend and backend independently.

## Changes (4 files)

| File | Change |
|---|---|
| `vite.config.ts` | `build.outDir` → `dist/client` (was `dist/public`) |
| `package.json` | `build`: `--outfile=dist/server/index.js` (was `--outdir=dist`); `start`: `node dist/server/index.js` |
| `server/_core/vite.ts` | `serveStatic` resolves `dist/client` (dev: `../../dist/client`, prod: `../client` relative to `dist/server/`) |
| `docs/ARCHITECTURE.md` | Updated build descriptions, commands table, and Node version requirement |

## How to Test

```bash
pnpm install
pnpm test        # 71 tests pass
pnpm build       # Verify dist/client/ and dist/server/index.js exist
pnpm start       # Smoke test in browser
```

**Build output structure:**
```
dist/
├── client/
│   ├── index.html
│   └── assets/
│       ├── index-*.js
│       └── index-*.css
└── server/
    └── index.js
```

## Risk / Impact

**Low.** Only 4 files changed (9 lines each direction). `pnpm dev` is unaffected (uses `tsx watch` on source files). All 71 tests pass. Build succeeds and produces correct output structure.

## Checklist

- [x] CI green (`pnpm test`: 71 passed, `pnpm build`: success)
- [x] No secrets in diff
- [x] No workflow changes
- [x] `pnpm dev` not broken (unchanged)
- [x] Docs updated (`ARCHITECTURE.md`)
- [x] Patch is minimal (4 files, 9 insertions / 9 deletions)

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Instruções arquiteturais atualizadas com estrutura clara de saídas de compilação e requisitos de runtime.

* **Chores**
  * Requisito mínimo de Node.js aumentado para versão 20.11+.
  * Reorganização da estrutura de artefatos de compilação para melhor organização de diretórios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->