### PR TITLE
docs: add deploy runbook (provider-agnostic)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -42,7 +42,7 @@ A arquitetura escolhida é **monolito** (Express serve API + assets estáticos),
 
 | Requisito | Versão | Referência |
 |---|---|---|
-| **Node.js** | 20+ (LTS recomendado) | `Dockerfile:2` — `node:20-alpine` |
+| **Node.js** | 20.11+ (LTS recomendado) | `Dockerfile:2` — `node:20-alpine`; projeto usa `import.meta.dirname` (requer >= 20.11) |
 | **pnpm** | 10.4.1 | `package.json` — campo `packageManager` |
 | **MySQL** | 8.0+ ou TiDB (MySQL-compatível) | `drizzle.config.ts` — dialect `mysql` |
 | **Git** | Qualquer versão recente | Para clonar o repositório |
@@ -68,7 +68,7 @@ Estas variáveis são fundamentais para o funcionamento da aplicação independe
 | `JWT_SECRET` | Sim | — | Segredo para assinatura de cookies de sessão. Deve ser uma string longa e aleatória (mínimo 32 caracteres). | `server/_core/env.ts:3` |
 | `PORT` | Não | `3000` | Porta HTTP do servidor. Se ocupada, o servidor tenta automaticamente até +20 portas acima. | `server/_core/index.ts` |
 | `NODE_ENV` | Não | — | Definir como `production` para deploy. Controla modo de execução (Vite dev vs. static serving). | `server/_core/env.ts:7` |
-| `OWNER_OPEN_ID` | Não | — | OpenID do proprietário. Usuários com este ID recebem role `admin` automaticamente no primeiro login. | `server/db.ts` |
+| `OWNER_OPEN_ID` | Não | — | OpenID do proprietário. Usuários com este ID recebem role `admin` automaticamente no primeiro login. | `server/_core/env.ts:6` |
 
 ### OAuth Manus (Temporárias — Fase de Migração)
 
@@ -147,7 +147,7 @@ pnpm start
 
 Após `pnpm build`, a pasta `dist/` contém:
 
-```
+```text
 dist/
 ├── client/          ← Assets estáticos (HTML, CSS, JS) gerados pelo Vite
 │   ├── index.html
@@ -270,13 +270,13 @@ A aplicação utiliza **MySQL 8.0+** ou **TiDB** (compatível com protocolo MySQ
 
 ### Formato da connection string
 
-```
+```plaintext
 mysql://usuario:senha@host:porta/nome_do_banco
 ```
 
 Exemplo para TiDB Cloud (com SSL):
 
-```
+```plaintext
 mysql://user:pass@gateway01.us-east-1.prod.aws.tidbcloud.com:4000/crusade?ssl={"rejectUnauthorized":true}
 ```
 


### PR DESCRIPTION
## Summary

Runbook de deploy completo e provider-agnostic para o período de migração. Documento único (`docs/deploy.md`) com 10 seções cobrindo desde pré-requisitos até cutover checklist.

## Why

Issue #39 — documentar deploy fora do Manus sem lock-in, seguindo o plano do CodeRabbit.

## How to test

- CI verde (docs only, sem mudanças de código)
- Revisar `docs/deploy.md` — todas as referências a arquivos do código são verificáveis

## Risk / Impact

- **Risco:** Nenhum — apenas documentação, zero mudanças de código
- **Impacto:** Habilita deploy independente da plataforma Manus

## Checklist

- [x] CI verde
- [x] Apenas documentação (sem mudanças de código/workflows)
- [x] Variáveis OAuth separadas: Manus (temporárias) vs GitHub (futuras)
- [x] Node.js direto como baseline, Docker como opcional
- [x] Referências a issues relacionadas (#38, #40, #41)
- [x] Idioma consistente com README (português)

## Notes for reviewers

Versão 1 do runbook de deploy. Segue o plano atualizado do CodeRabbit com duas design choices:
1. Node.js direto como baseline (mais simples e portável durante migração)
2. OAuth Manus separado de futuro GitHub OAuth (facilita remoção pós-PR 3.2)

Closes #39

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentação**
  * Adicionada documentação de implantação abrangente: guia passo a passo para deploy monolítico (Node.js e opcional Docker), pré-requisitos, configuração de variáveis de ambiente, build e gestão de processo em produção, migrações e verificação de integridade, troubleshooting, checklists de pré/pós/turno e exemplos provider-agnostic para diferentes provedores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->