### PR TITLE
UI-ASSET-01C follow-up: sync JSX asset wrappers with themed CSS selectors

### DIFF
--- a/client/src/components/CommandPanels.tsx
+++ b/client/src/components/CommandPanels.tsx
@@ -24,15 +24,17 @@ export function StatusSeal({
   const base = sealByTone[tone];
   return (
     <div className={cn("status-seal", className)}>
-      <picture>
-        <source srcSet={`${base}.webp`} type="image/webp" />
-        <img
-          src={`${base}.png`}
-          alt=""
-          aria-hidden="true"
-          className="status-seal__image"
-        />
-      </picture>
+      <span className="status-seal__asset" aria-hidden="true">
+        <picture className="status-seal__asset-picture">
+          <source srcSet={`${base}.webp`} type="image/webp" />
+          <img
+            src={`${base}.png`}
+            alt=""
+            aria-hidden="true"
+            className="status-seal__image"
+          />
+        </picture>
+      </span>
       <span className="status-seal__label">{label}</span>
     </div>
   );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -306,6 +306,13 @@
     pointer-events: none;
   }
 
+  .campaign-command-header__strip-picture,
+  .campaign-command-header__sigil-picture {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
   .campaign-command-header__strip {
     inset: 0 auto auto 0;
     width: 100%;
@@ -493,6 +500,13 @@
     background: color-mix(in oklch, var(--background) 85%, black 15%);
   }
 
+  .status-seal__asset,
+  .status-seal__asset-picture {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .status-seal__image {
     width: 1.5rem;
     height: 1.5rem;
@@ -531,6 +545,13 @@
     inset: 0;
     pointer-events: none;
     z-index: 0;
+  }
+
+  .login-bg-overlay__picture,
+  .login-sigil__picture {
+    display: block;
+    width: 100%;
+    height: 100%;
   }
 
   .login-bg-overlay__image {

--- a/client/src/pages/Campaigns.tsx
+++ b/client/src/pages/Campaigns.tsx
@@ -104,31 +104,35 @@ export default function Campaigns() {
     <div className="min-h-screen bg-background">
       <div className="container mx-auto py-8 space-y-6">
         <header className="campaign-command-header">
-          <picture className="campaign-command-header__strip" aria-hidden="true">
-            <source
-              srcSet="/assets/ui-theme/overlays/dossier-header-strip.webp"
-              type="image/webp"
-            />
-            <img
-              src="/assets/ui-theme/overlays/dossier-header-strip.png"
-              alt=""
-              aria-hidden="true"
-              className="campaign-command-header__strip-image"
-            />
-          </picture>
+          <div className="campaign-command-header__strip" aria-hidden="true">
+            <picture className="campaign-command-header__strip-picture">
+              <source
+                srcSet="/assets/ui-theme/overlays/dossier-header-strip.webp"
+                type="image/webp"
+              />
+              <img
+                src="/assets/ui-theme/overlays/dossier-header-strip.png"
+                alt=""
+                aria-hidden="true"
+                className="campaign-command-header__strip-image"
+              />
+            </picture>
+          </div>
 
-          <picture className="campaign-command-header__sigil" aria-hidden="true">
-            <source
-              srcSet="/assets/ui-theme/overlays/command-sigil-watermark.webp"
-              type="image/webp"
-            />
-            <img
-              src="/assets/ui-theme/overlays/command-sigil-watermark.png"
-              alt=""
-              aria-hidden="true"
-              className="campaign-command-header__sigil-image"
-            />
-          </picture>
+          <div className="campaign-command-header__sigil" aria-hidden="true">
+            <picture className="campaign-command-header__sigil-picture">
+              <source
+                srcSet="/assets/ui-theme/overlays/command-sigil-watermark.webp"
+                type="image/webp"
+              />
+              <img
+                src="/assets/ui-theme/overlays/command-sigil-watermark.png"
+                alt=""
+                aria-hidden="true"
+                className="campaign-command-header__sigil-image"
+              />
+            </picture>
+          </div>
 
           <div className="campaign-command-header__content">
             <div className="campaign-command-header__heading">

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -35,35 +35,39 @@ export default function Home() {
     return (
       <div className="login-page min-h-screen flex flex-col items-center justify-center p-4">
         {/* Explicit runtime asset layer: grimdark metal background */}
-        <picture className="login-bg-overlay" aria-hidden="true">
-          <source
-            srcSet="/assets/ui-theme/backgrounds/grimdark-metal-bg.webp"
-            type="image/webp"
-          />
-          <img
-            src="/assets/ui-theme/backgrounds/grimdark-metal-bg.png"
-            alt=""
-            aria-hidden="true"
-            className="login-bg-overlay__image"
-          />
-        </picture>
+        <div className="login-bg-overlay" aria-hidden="true">
+          <picture className="login-bg-overlay__picture">
+            <source
+              srcSet="/assets/ui-theme/backgrounds/grimdark-metal-bg.webp"
+              type="image/webp"
+            />
+            <img
+              src="/assets/ui-theme/backgrounds/grimdark-metal-bg.png"
+              alt=""
+              aria-hidden="true"
+              className="login-bg-overlay__image"
+            />
+          </picture>
+        </div>
 
         {/* Hero + card area — constrained to max-w-md so the watermark is centered
              behind both title and login card as a single visual unit */}
         <div className="login-hero max-w-md w-full">
           {/* Explicit runtime asset layer: command sigil watermark */}
-          <picture className="login-sigil" aria-hidden="true">
-            <source
-              srcSet="/assets/ui-theme/overlays/command-sigil-watermark.webp"
-              type="image/webp"
-            />
-            <img
-              src="/assets/ui-theme/overlays/command-sigil-watermark.png"
-              alt=""
-              aria-hidden="true"
-              className="login-sigil__image"
-            />
-          </picture>
+          <div className="login-sigil" aria-hidden="true">
+            <picture className="login-sigil__picture">
+              <source
+                srcSet="/assets/ui-theme/overlays/command-sigil-watermark.webp"
+                type="image/webp"
+              />
+              <img
+                src="/assets/ui-theme/overlays/command-sigil-watermark.png"
+                alt=""
+                aria-hidden="true"
+                className="login-sigil__image"
+              />
+            </picture>
+          </div>
 
           <div className="text-center mb-8 relative z-10 w-full">
             <Sword className="h-20 w-20 mx-auto mb-4 text-primary" />


### PR DESCRIPTION
### Motivation
- Fix broken image placeholders and inconsistent theming caused by JSX `picture` elements being the positioned node while the CSS expected block-level wrapper elements. 
- Align component markup with the class structure already defined in the theme `index.css` so runtime overlays (campaign header, seals, login) inherit sizing and positioning reliably. 
- Restrict changes to the login, campaign list and shared command panel asset wrappers without altering battle screens or campaign detail logic.

### Description
- Updated `StatusSeal` markup to add explicit wrappers `status-seal__asset` and `status-seal__asset-picture` so the seal image matches the CSS hierarchy in `client/src/components/CommandPanels.tsx`.  
- Replaced positioned `picture` nodes in the campaign header with wrapper containers plus picture children: `campaign-command-header__strip` / `campaign-command-header__strip-picture` and `campaign-command-header__sigil` / `campaign-command-header__sigil-picture` in `client/src/pages/Campaigns.tsx`.  
- Mirrored the same pattern for login overlays by introducing `login-bg-overlay` / `login-bg-overlay__picture` and `login-sigil` / `login-sigil__picture` in `client/src/pages/Home.tsx`.  
- Added CSS rules in `client/src/index.css` for the new `*__picture` and seal asset wrapper selectors so overlays and seals reliably inherit width/height and the expected positioning.

### Testing
- Ran `pnpm check` (TypeScript `tsc --noEmit`) which started but timed out in this environment (`EXIT:124`).  
- Started the dev server with `pnpm dev` which successfully launched and served the app at `http://localhost:3000/`.  
- Executed an automated Playwright script that captured a screenshot artifact (`artifacts/login-page.png`) of the login page, and the script completed successfully producing the artifact.  
- Attempted `pnpm lint` but the project has no `lint` script defined so the command failed with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b844245ae48327af8bbe9d1441b961)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Notas de Lançamento

* **Refactor**
  * Reorganizada estrutura interna de componentes para otimizar a organização de elementos visuais

* **Style**
  * Adicionadas regras de estilos CSS para garantir renderização consistente de imagens em toda a aplicação

<!-- end of auto-generated comment: release notes by coderabbit.ai -->